### PR TITLE
Fix build for zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,11 +60,10 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
-        .name = "deflate",
+    const lib = b.addLibrary(.{ .name = "deflate", .root_module = b.createModule(.{
         .target = target,
         .optimize = optimize,
-    });
+    }), .linkage = std.builtin.LinkMode.static });
     lib.linkLibC();
     lib.addIncludePath(b.path("."));
     lib.addCSourceFiles(.{ .files = &source_files, .flags = &flags });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "libdeflate",
+    .name = .libdeflate,
+    .fingerprint = 0x3583a8cae14dd9df,
     .version = "1.18.0-1",
     .dependencies = .{},
     .paths = .{


### PR DESCRIPTION
```
$ ar -t zig-out/lib/libdeflate.a 
.zig-cache/o/69180d6215a19289e7272ec5eecaa739/cpu_features.o
.zig-cache/o/956581e01811c2ecdb8e10b29f8ce745/utils.o
.zig-cache/o/784548770d5676897a06fa5bdc3c17c0/cpu_features.o
.zig-cache/o/c888213446634e933f890c50b8da4848/deflate_compress.o
.zig-cache/o/357bdae6cdcbcd0a5bb0c9e19c6ef3ff/deflate_decompress.o
.zig-cache/o/f86febf4e4f059d479121aaa6167e794/adler32.o
.zig-cache/o/89bbdcdb7af8f977d1049c672d245ff5/zlib_compress.o
.zig-cache/o/e35bf7f7da9e165145441a8443d2e0b0/zlib_decompress.o
.zig-cache/o/f19a7715d15932ae8ca1a62374e5270d/gzip_compress.o
.zig-cache/o/61a8bbc950cbc5b12b771fab513ce6fb/gzip_decompress.o
```